### PR TITLE
Ignore phpcs on tests

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -66,4 +66,10 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.access-token }}
         run: |
-          vendor/bin/phpcs --report=json ${CHANGED_FILES} | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' | reviewdog -efm="%f:%l:%c:%m" -name="phpcs" -filter-mode="added" -fail-on-error=true -reporter=github-pr-review
+          JSON_REPORT=$(vendor/bin/phpcs --report=json $CHANGED_FILES)
+          echo $JSON_REPORT | jq empty
+          if [ $? -ne 0 ]; then
+            echo "Invalid JSON"
+            exit 1
+          fi
+          echo $JSON_REPORT | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' | reviewdog -efm="%f:%l:%c:%m" -name="phpcs" -filter-mode="added" -fail-on-error=true -reporter=github-pr-review

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Get list of changed files
         id: files
         run: |
-          echo "CHANGED_FILES=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '\.php$' | tr '\n' ' ')" >> $GITHUB_ENV
+          echo "CHANGED_FILES=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep '\.php$' | tr '\n' ' ')" >> $GITHUB_ENV
 
       # ------------------------------------------------------------------------------
       # PHPCS


### PR DESCRIPTION
Ignore phpcs on tests. It can cause failing silently when a test file is produced with spaces on its name.

See action https://github.com/the-events-calendar/events-community/actions/runs/9548501032/job/26315827269?pr=690

and slack discussion https://lw.slack.com/archives/C01H7Q57P1C/p1718650569300489