### PR TITLE
--ignore-platform-reqs in PHPCS

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           php-version: ${{ inputs.php_version }}
       - uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--ignore-platform-reqs"
 
       - name: "Give permissions"
         run: |


### PR DESCRIPTION
Not ignoring platform requirements leads to workflows where an extension
present in the test environment (e.g. `uopz`) and required by a
development dependency (e.g. the `slope-it/clock-mock` one) will prevent
the installation of Composer dependencies in the context of the PHPCS
action.

[Example](https://github.com/the-events-calendar/event-tickets/actions/runs/10351870313/job/28651279984?pr=3159#step:6:92)