### PR TITLE
bump checkout, cache and setup-node actions to their latest versions

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -19,7 +19,7 @@ jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -31,7 +31,7 @@ jobs:
         id: get-composer-cache-dir
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: composer-cache
         with:
           path: ${{ steps.get-composer-cache-dir.outputs.dir }}

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -95,7 +95,7 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         if: steps.check-nvmrc.outputs.exists == 'true'
         with:
           node-version-file: '.nvmrc'
@@ -176,7 +176,7 @@ jobs:
         id: get_composer_cache_dir
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         if: steps.s3_zip_exists.outcome != 'success'
         id: composer_cache
         with:


### PR DESCRIPTION
Prevent warnings when these are run in workflows