### PR TITLE
Chore: bump GitHub action versions

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -24,25 +24,11 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      # ------------------------------------------------------------------------------
-      # Prepare our cache directories
-      # ------------------------------------------------------------------------------
-      - name: Get Composer Cache Directory
-        id: get-composer-cache-dir
-        run: |
-          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
-        id: composer-cache
-        with:
-          path: ${{ steps.get-composer-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - uses: "shivammathur/setup-php@v2"
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php_version }}
-      - uses: "ramsey/composer-install@v2"
+
+      - uses: ramsey/composer-install@v3
         with:
           composer-options: "--ignore-platform-reqs"
 

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -111,7 +111,7 @@ jobs:
       # Setup bun.
       # ------------------------------------------------------------------------------
       - name: Setup bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 


### PR DESCRIPTION
### Main Changes
- bump `oven-sh/setup-bun` to v2.
- bump `ramsey/composer-install` to v3.
- remove useless composer caching steps, `ramsey/composer-install` does this automatically.