### PR TITLE
Fix uploading plugin artifact

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -264,3 +264,4 @@ jobs:
         with:
           name: ${{ env.ZIP_NAME }}
           path: .pup-zip
+          include-hidden-files: true


### PR DESCRIPTION
## Issue

The uploading artifact fails with `Warning: No files were found with the provided path: .pup-zip. No artifacts will be uploaded.` notice.

## Solution

It's related to the BC of `actions/upload-artifact@v4`: `include-hidden-files` is false by default (see https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#hidden-files). That's why we must add `include-hidden-files: true` to upload files from the `.pup-zip` directory. I've tested it in our project; it works as expected.