### PR TITLE
Make sure we have valid JSON for PHPCS

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -55,7 +55,7 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.access-token }}
         run: |
           # Run phpcs and capture both the output and the exit code
-          JSON_REPORT=$(vendor/bin/phpcs --report=json ${{ env.CHANGED_FILES }} || echo "")
+          JSON_REPORT=$(vendor/bin/phpcs --report=json -q ${{ env.CHANGED_FILES }} || echo "")
           PHPCS_EXIT_CODE=$?
 
           # Check if phpcs produced a JSON report


### PR DESCRIPTION
PHPCS config might contain `<arg value="p"/>`. In this case, we got invalid JSON like
```
$ vendor/bin/phpcs --report=json ./src/functions/boot.php 
. 1 / 1 (100%)


{"totals":{"errors":0,"warnings":0,"fixable":0},"files":{"\/src\/functions\/boot.php":{"errors":0,"warnings":0,"messages":[]}}}
Time: 72ms; Memory: 14MB
```
With the the `-q` option, we ensure progress information will be suppressed (see https://github.com/squizlabs/PHP_CodeSniffer/issues/969).