### PR TITLE
Allow bun to use node auth token for authentication

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -73,6 +73,9 @@ on:
 jobs:
   generate-zip:
     runs-on: ubuntu-latest
+    env:
+      BUN_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+
     steps:
       # ------------------------------------------------------------------------------
       # Checkout the repo.
@@ -224,7 +227,7 @@ jobs:
       - name: pup package
         id: pup_package
         if: steps.s3_zip_exists.outcome != 'success'
-        run:  composer -- pup package ${{ env.VERSION }}
+        run: composer -- pup package ${{ env.VERSION }}
 
       - name: Create the zip_files folder
         if: steps.s3_zip_exists.outcome != 'success'


### PR DESCRIPTION
As per the [docs](https://github.com/oven-sh/setup-bun?tab=readme-ov-file#using-a-custom-npm-registry) this should allow bun to access private repositories with the NODE_AUTH_TOKEN.

This fixes [my zip builds](https://github.com/ithemes/solid-performance/actions/runs/14629426345).