### PR TITLE
Fix: Prevent duplicate pup build calls when a composer token is provided

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -200,7 +200,7 @@ jobs:
           fi
 
       - name: pup build
-        if: steps.s3_zip_exists.outcome != 'success'
+        if: steps.s3_zip_exists.outcome != 'success' && env.COMPOSER_TOKEN_AVAILABLE == 'false'
         run: composer -- pup build
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
Previously, if a COMPOSER_TOKEN was present, both the "pup build" step and the "pup build with composer auth" step would attempt to run composer -- pup build. This led to duplicate build operations.

The change modifies the "pup build" step to only execute when env.COMPOSER_TOKEN_AVAILABLE is false. This ensures that the pup build command runs only once, either using the Composer token (if available) or without it.