### PR TITLE
fix: skip phpcs when no PHP files changed, handle filenames with spaces

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -29,21 +29,9 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ inputs.php_version }}
-
-      - uses: ramsey/composer-install@v3
-        with:
-          composer-options: "--ignore-platform-reqs"
-
-      - name: "Give permissions"
-        if: ${{ inputs.change_permissions }}
-        run: |
-          sudo chown -R root:root $GITHUB_WORKSPACE
-
       # ------------------------------------------------------------------------------
-      # Get changed files
+      # Get changed files — runs right after checkout so we can skip remaining
+      # steps entirely when no PHP files changed
       # ------------------------------------------------------------------------------
       - name: Get list of changed files
         id: files
@@ -54,24 +42,42 @@ jobs:
             echo EOF
           } >> $GITHUB_ENV
 
+          if git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep -q '\.php$'; then
+            echo "has_php_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "No PHP files changed, skipping phpcs"
+            echo "has_php_files=false" >> $GITHUB_OUTPUT
+          fi
+
+      - uses: shivammathur/setup-php@v2
+        if: steps.files.outputs.has_php_files == 'true'
+        with:
+          php-version: ${{ inputs.php_version }}
+
+      - uses: ramsey/composer-install@v3
+        if: steps.files.outputs.has_php_files == 'true'
+        with:
+          composer-options: "--ignore-platform-reqs"
+
+      - name: "Give permissions"
+        if: ${{ inputs.change_permissions }}
+        run: |
+          sudo chown -R root:root $GITHUB_WORKSPACE
+
       # ------------------------------------------------------------------------------
       # PHPCS
       # ------------------------------------------------------------------------------
       - uses: reviewdog/action-setup@v1
+        if: steps.files.outputs.has_php_files == 'true'
         with:
           reviewdog_version: latest # Optional. [latest,nightly,v.X.Y.Z]
       - name: Run reviewdog
+        if: steps.files.outputs.has_php_files == 'true'
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.access-token }}
         run: |
-          # Skip when no PHP files changed
-          if [ -z "${{ env.CHANGED_FILES }}" ]; then
-            echo "No PHP files changed, skipping phpcs"
-            exit 0
-          fi
-
-          # Run phpcs — use xargs so filenames with spaces are handled correctly
-          JSON_REPORT=$(echo \"${{ env.CHANGED_FILES }}\" | xargs -d '\n' vendor/bin/phpcs --report=json -q)
+          # Run phpcs — printf + xargs -d '\n' keeps filenames with spaces intact
+          JSON_REPORT=$(printf '%s\n' "${{ env.CHANGED_FILES }}" | xargs -d '\n' vendor/bin/phpcs --report=json -q)
           PHPCS_EXIT_CODE=$?
 
           # Check if phpcs produced a JSON report

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -48,7 +48,11 @@ jobs:
       - name: Get list of changed files
         id: files
         run: |
-          echo "CHANGED_FILES=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep '\.php$' | tr '\n' ' ')" >> $GITHUB_ENV
+          {
+            echo 'CHANGED_FILES<<EOF'
+            git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep '\.php$' || true
+            echo EOF
+          } >> $GITHUB_ENV
 
       # ------------------------------------------------------------------------------
       # PHPCS
@@ -60,8 +64,14 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.access-token }}
         run: |
-          # Run phpcs and capture both the output and the exit code
-          JSON_REPORT=$(vendor/bin/phpcs --report=json -q ${{ env.CHANGED_FILES }} || echo "")
+          # Skip when no PHP files changed
+          if [ -z "${{ env.CHANGED_FILES }}" ]; then
+            echo "No PHP files changed, skipping phpcs"
+            exit 0
+          fi
+
+          # Run phpcs — use xargs so filenames with spaces are handled correctly
+          JSON_REPORT=$(echo \"${{ env.CHANGED_FILES }}\" | xargs -d '\n' vendor/bin/phpcs --report=json -q)
           PHPCS_EXIT_CODE=$?
 
           # Check if phpcs produced a JSON report

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -36,18 +36,20 @@ jobs:
       - name: Get list of changed files
         id: files
         run: |
-          {
-            echo 'CHANGED_FILES<<EOF'
-            git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep '\.php$' || true
-            echo EOF
-          } >> $GITHUB_ENV
-
-          if git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep -q '\.php$'; then
-            echo "has_php_files=true" >> $GITHUB_OUTPUT
-          else
-            echo "No PHP files changed, skipping phpcs"
-            echo "has_php_files=false" >> $GITHUB_OUTPUT
-          fi
+            CHANGED_FILES=$(git diff --name-only --diff-filter=AM ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -- . ':!tests' | grep '\.php$' || true)                                                                                                                       
+                                                                                                                                                                                                                                                                                                                    
+            {                                                                                                                                                                                                                                                                                                       
+              echo 'CHANGED_FILES<<EOF'                                                                                                                                                                                                                                                                             
+              echo "$CHANGED_FILES"                                                                                                                                                                                                                                                                                 
+              echo EOF                                                                                                                                                                                                                                                                                              
+            } >> $GITHUB_ENV                                                                                                                                                                                                                                                                                        
+                                                                                                                                                                                                                                                                                                                    
+            if [ -n "$CHANGED_FILES" ]; then                                                                                                                                                                                                                                                                        
+              echo "has_php_files=true" >> $GITHUB_OUTPUT                                                                                                                                                                                                                                                           
+            else                                                                                                                                                                                                                                                                                                    
+              echo "No PHP files changed, skipping phpcs"                                                                                                                                                                                                                                                           
+              echo "has_php_files=false" >> $GITHUB_OUTPUT                                                                                                                                                                                                                                                          
+            fi
 
       - uses: shivammathur/setup-php@v2
         if: steps.files.outputs.has_php_files == 'true'


### PR DESCRIPTION
When CHANGED_FILES is empty (no PHP files in the PR), phpcs was called with no file arguments. Depending on the repo phpcs.xml, this either produced a non-JSON error string (failing jq validation → exit 1) or scanned the entire codebase unintentionally.

Also switches from bare variable expansion to xargs so filenames containing spaces are passed as individual arguments rather than being split on whitespace.

## 

## Additional context:
https://lw.slack.com/archives/C09T9KPV9HV/p1782497266594449

### Troubleshooting Screenshots

<img width="968" height="545" alt="image" src="https://github.com/user-attachments/assets/8886b84f-ff22-4049-96c9-c9006f1a8630" />

<img width="964" height="545" alt="image" src="https://github.com/user-attachments/assets/d65f2ee9-c1f5-41f0-868a-296a5d4ad6e9" />

<img width="979" height="746" alt="image" src="https://github.com/user-attachments/assets/f97450a5-57b7-4aea-a2e7-8f2e0d810a12" />

<img width="962" height="503" alt="image" src="https://github.com/user-attachments/assets/a5d80555-1a00-465f-a3cb-62271fd358b6" />


