### PR TITLE
fix: issue where zip action won't work for bun setup

### DIFF
--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -98,11 +98,20 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Check for npm lockfile
+        id: check-lockfile
+        run: |
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ] || [ -f yarn.lock ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - uses: actions/setup-node@v4
         if: steps.check-nvmrc.outputs.exists == 'true'
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
+          cache: ${{ steps.check-lockfile.outputs.exists == 'true' && 'npm' || '' }}
 
       - name: Set up authentication for NODE_AUTH_TOKEN if present
         run: |

--- a/.github/workflows/zip.yml
+++ b/.github/workflows/zip.yml
@@ -98,6 +98,10 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      # ------------------------------------------------------------------------------
+      # Ensures actions/setup-node works as-expected in scenarios where a npm lockfile
+      # doesn't exist, such as when only bun is used.
+      # ------------------------------------------------------------------------------
       - name: Check for npm lockfile
         id: check-lockfile
         run: |


### PR DESCRIPTION
Bun-only repos have no package-lock.json, which made setup-node's npm cache fail with "Dependencies lock file is not found" error. 

Added a check for package-lock.json file, if this file doesn't exist then we skip the cache during the `actions/setup-node@v4` step. 


